### PR TITLE
Added check for install folder and shows an error to the admin.

### DIFF
--- a/admin/sources/adm_dashboard_main.php
+++ b/admin/sources/adm_dashboard_main.php
@@ -89,6 +89,12 @@
 	<h1>Dashboard</h1>
 
 	<div id="content">
+		<?php
+		//checks to see if install directory is still on the server, and shows a warning.
+		if(file_exists(__DIR__.'/../../install') || is_dir(__DIR__.'/../../install')){
+			echo HTML::Notification('It is recommended to delete the install folder.','error',true);
+		}
+		?>
 		<div class="grid-row">
 			<!-- LEFT -->
 			<div class="grid-half">

--- a/admin/sources/adm_dashboard_main.php
+++ b/admin/sources/adm_dashboard_main.php
@@ -92,7 +92,7 @@
 		<?php
 		//checks to see if install directory is still on the server, and shows a warning.
 		if(file_exists(__DIR__.'/../../install') || is_dir(__DIR__.'/../../install')){
-			echo HTML::Notification('It is recommended to delete the install folder.','error',true);
+			echo HTML::Notification('It is recommended to delete the install folder.','warning',true);
 		}
 		?>
 		<div class="grid-row">


### PR DESCRIPTION
I believe that an error should be shown to the admin, asking them to delete the install folder. While the install script puts a lock, it should also be recommended to just delete the entire install folder as it isn't needed anymore.